### PR TITLE
Remove redundant COPY command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM python:3
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
-COPY requirements.txt /code/
-RUN pip install -r requirements.txt
 COPY . /code/
+RUN pip install -r requirements.txt
 RUN python manage.py collectstatic
 RUN python manage.py makemigrations
 RUN python manage.py migrate


### PR DESCRIPTION
The file `requirements.txt` is already copied when the command `COPY . /code/` is issued.